### PR TITLE
Remove conditional logic

### DIFF
--- a/controls/chef-client.rb
+++ b/controls/chef-client.rb
@@ -1,28 +1,15 @@
 # encoding: utf-8
-# copyright: 2017, The Authors
+# copyright: 2018, The Authors
 
 title 'chef-client version'
 
-if os[:family] == 'linux' || 'bsd'
-  control 'chef-client-1.0' do
-    impact 1.0
-    title 'Verify the version of chef-client'
-    desc  '
-      This is a profile verifies you are running a modern version of chef client.
-    '
-    describe command('chef-client --version') do
-      its('stdout') { should match (/Chef: 1[3-9]/) }
-    end
-  end
-elsif os[:family] == 'windows'
-  control 'chef-client-1.0' do
-    impact 1.0
-    title 'Verify the version of chef-client'
-    desc  '
-      This is a profile verifies you are running a modern version of chef client.
-    '
-    describe command('chef-client --version') do
-      its('stdout') { should match (/Chef: 1[3-9]/) }
-    end
+control 'chef-client-1.0' do
+  impact 1.0
+  title 'Verify the version of chef-client'
+  desc  '
+    This is a profile verifies you are running a modern version of chef client.
+  '
+  describe command('chef-client --version') do
+    its('stdout') { should match (/Chef: 1[3-9]/) }
   end
 end


### PR DESCRIPTION
The code:

```
if os[:family] == 'linux' || 'bsd'
```

means:

```
if (os[:family] == 'linux') || 'bsd'
```

which always evaluates to `true`.

When I changed it to:

```
if os[:family] == 'linux' || os[:family] == 'bsd'
```

the tests were skipped entirely (on Ubuntu).

Rather than debugging the issue, I removed the conditional logic because both code paths are identical.